### PR TITLE
remove the need for GM_info

### DIFF
--- a/StateFarmClient.js
+++ b/StateFarmClient.js
@@ -84,6 +84,8 @@
 // @updateURL https://update.greasyfork.org/scripts/482982/StateFarm%20Client%20V3%20-%20Combat%2C%20Bloom%2C%20ESP%2C%20Rendering%2C%20Chat%2C%20Automation%2C%20Botting%2C%20Unbanning%20and%20more.meta.js
 // ==/UserScript==
 
+if (typeof GM_info === 'undefined') GM_info = {};
+
 let attemptedInjection = false;
 console.log("StateFarm: running (before function)");
 


### PR DESCRIPTION
although GM_info is still used, it doesn't actually need to be there anymore.
this will not change how SF runs **at all**, except for userscript/injectors that don't parse Tampermonkey values, this provides an alternative.

built for SF support in my "crackedshell" proxy (i'm not parsing tampermonkey flags).