### PR TITLE
add crackedshell meta

### DIFF
--- a/StateFarmClient.js
+++ b/StateFarmClient.js
@@ -84,6 +84,12 @@
 // @updateURL https://update.greasyfork.org/scripts/482982/StateFarm%20Client%20V3%20-%20Combat%2C%20Bloom%2C%20ESP%2C%20Rendering%2C%20Chat%2C%20Automation%2C%20Botting%2C%20Unbanning%20and%20more.meta.js
 // ==/UserScript==
 
+// {{CRACKEDSHELL}}
+// require:"https://cdn.jsdelivr.net/npm/tweakpane@3.1.10/dist/tweakpane.min.js"
+// require:"https://cdnjs.cloudflare.com/ajax/libs/crypto-js/4.1.1/crypto-js.min.js"
+// require:"https://cdnjs.cloudflare.com/ajax/libs/jszip/3.7.1/jszip.min.js"
+// {{!CRACKEDSHELL}}
+
 let attemptedInjection = false;
 console.log("StateFarm: running (before function)");
 


### PR DESCRIPTION
i'm not gonna add a raw tampermonkey parser, so i made this quick meta parser.
this works on the latest build of crackedshell i've made.
the menu seems to glitch out though - not quite sure why, but it is what it is. i'll try to debug it once i release.

when crackshell is released into prod, it will be on my [github](https://github.com/VillainsRule/CrackedShell). i'll release tonight or tomorrow night.