### PR TITLE
showMinAngle remove fix

### DIFF
--- a/StateFarmClient.js
+++ b/StateFarmClient.js
@@ -5617,11 +5617,11 @@ z-index: 999999;
                         minangleCircle.style.height = extract("aimbotMinAngle") * idkWhatThisIs + 'px';
                         minangleCircle.style.bottom = offsettedY + 'px';
                         minangleCircle.style.right = offsettedX + 'px';
-                    } else {
-                        minangleCircle.style.display = 'none';
                     };
                 };
-
+                if (!extract("showMinAngle")) {
+                    minangleCircle.style.display = 'none';
+                };
                 // playerNearest=undefined; //currently unused and not defined
                 // enemyLookingAt=undefined; //currently unused and not defined
 


### PR DESCRIPTION
circle is now removed correctly after module deactivation.
moved out of the if(showBloom || showMinAngle)-statement so it will be removed even without showBloom enabled