### PR TITLE
showMinAngle center fix?

### DIFF
--- a/StateFarmClient.js
+++ b/StateFarmClient.js
@@ -5615,8 +5615,8 @@ z-index: 999999;
                         let idkWhatThisIs = 25 * (1.25 / ss.CAMERA.fov);
                         minangleCircle.style.width = extract("aimbotMinAngle") * idkWhatThisIs + 'px';
                         minangleCircle.style.height = extract("aimbotMinAngle") * idkWhatThisIs + 'px';
-                        minangleCircle.style.bottom = offsettedY + 'px';
-                        minangleCircle.style.right = offsettedX + 'px';
+                        minangleCircle.style.bottom = centerY + 'px';
+                        minangleCircle.style.right = centerX + 'px';
                     };
                 };
                 if (!extract("showMinAngle")) {


### PR DESCRIPTION
someone double-check this, but there is no reason why the minAngle circle should center around the bloom indicator instead of the crosshair, as the minAngle calc should use then player's view, right?????