### PR TITLE
pre27 fix grenade power

### DIFF
--- a/StateFarmClient.js
+++ b/StateFarmClient.js
@@ -32,7 +32,7 @@
     //3.#.#-release for release (in the unlikely event that happens)
 // this ensures that each version of the script is counted as different
 
-// @version      3.4.3-pre26
+// @version      3.4.3-pre27
 
 // @match        *://*.shellshock.io/*
 // @match        *://*.algebra.best/*
@@ -5637,6 +5637,7 @@ z-index: 999999;
         createAnonFunction('getGrenadeValue', function () {
             try {
                 if (extract('grenadeMax')) return extract('grenadePower');
+		return ss.grenadeThrowPower;
             } catch {
                 return ss.grenadeThrowPower;
             }


### PR DESCRIPTION
issue was that the default return was in the catch block, so if the function didn't error it returned nothing. (this is why you want TYPES in your language)